### PR TITLE
[plugin-replace] Document the `values` option

### DIFF
--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -119,16 +119,15 @@ A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns
 Type: `{ [key: String]: Replacement }`, where `Replacement` is either a string or a `function` that returns a string.
 Default: `{}`
 
-To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option:
+To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option. For example, the following two signatures are equivalent:
 
 ```js
 replace({
   include: ["src/**/*.js"],
   changed: "replaced"
 });
-
-// ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇
-
+```
+```js
 replace({
   include: ["src/**/*.js"],
   values: {

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -114,6 +114,29 @@ Default: `null`
 
 A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
+### `values`
+
+Type: `{ [key: String]: Replacement }`, where `Replacement` is either a string or a `function` that returns a string.
+Default: `{}`
+
+To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option:
+
+```js
+replace({
+  include: [/src/],
+  changed: "replaced"
+});
+
+// ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇
+
+replace({
+  include: [/src/],
+  values: {
+    changed: "replaced"
+  }
+});
+```
+
 ## Word Boundaries
 
 By default, values will only match if they are surrounded by _word boundaries_.

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -123,14 +123,14 @@ To avoid mixing replacement strings with the other options, you can specify repl
 
 ```js
 replace({
-  include: [/src/],
+  include: ["src/**/*.js"],
   changed: "replaced"
 });
 
 // ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇ ⬇
 
 replace({
-  include: [/src/],
+  include: ["src/**/*.js"],
   values: {
     changed: "replaced"
   }

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -119,7 +119,7 @@ A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns
 Type: `{ [key: String]: Replacement }`, where `Replacement` is either a string or a `function` that returns a string.
 Default: `{}`
 
-To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option. For example, the following signatures:
+To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option. For example, the following signature:
 
 ```js
 replace({

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -119,7 +119,7 @@ A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns
 Type: `{ [key: String]: Replacement }`, where `Replacement` is either a string or a `function` that returns a string.
 Default: `{}`
 
-To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option. For example, the following two signatures are equivalent:
+To avoid mixing replacement strings with the other options, you can specify replacements in the `values` option. For example, the following signatures:
 
 ```js
 replace({
@@ -127,6 +127,9 @@ replace({
   changed: "replaced"
 });
 ```
+
+Can be replaced with:
+
 ```js
 replace({
   include: ["src/**/*.js"],


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-replace`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

List any relevant issue numbers:

### Description

I discovered this option because it was used in the `preventAssignment` example, but it wasn't documented.

I got the option type from the `.d.ts` file.
